### PR TITLE
set PATH so the app can be found in /usr/local/bin at boot

### DIFF
--- a/squadron/init/init-script-ubuntu
+++ b/squadron/init/init-script-ubuntu
@@ -2,6 +2,7 @@
 # Starts and stops the squadron daemon
 #
 
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 SQUADRON=`which squadron`
 DIR="{}"
 SQUADRON_PID="$DIR/squadron.pid"


### PR DESCRIPTION
/usr/local/bin isn't in the PATH by default at boot and this avoids an
error: start-stop-daemon: unable to stat /var/squadron/--make-pidfile (No such file or directory)