### PR TITLE
Add LSB info to init script so the service is properly enabled

### DIFF
--- a/squadron/init/init-script-ubuntu
+++ b/squadron/init/init-script-ubuntu
@@ -1,6 +1,13 @@
 #!/bin/sh
-# Starts and stops the squadron daemon
-#
+
+### BEGIN INIT INFO
+# Provides:          squadron
+# Required-Start:    $network $syslog
+# Required-Stop:     $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start Squadron
+### END INIT INFO
 
 SQUADRON=`which squadron`
 DIR="{}"


### PR DESCRIPTION
Resolves #29  

LSB start/stop info was missing from the init script, leading to errors when enabling the service. 

Before: 

```
# systemctl enable squadron
squadron.service is not a native service, redirecting to systemd-sysv-install
Executing /lib/systemd/systemd-sysv-install enable squadron
insserv: warning: script 'K01squadron' missing LSB tags and overrides
insserv: warning: script 'squadron' missing LSB tags and overrides
update-rc.d: error: squadron Default-Start contains no runlevels, aborting.
root@default-ubuntu-1604:/etc/init.d# echo $?
1
```

After: 

```
# systemctl enable squadron
squadron.service is not a native service, redirecting to systemd-sysv-install
Executing /lib/systemd/systemd-sysv-install enable squadron
insserv: warning: current start runlevel(s) (empty) of script `squadron' overrides LSB defaults (2 3 4 5).
insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `squadron' overrides LSB defaults (0 1 6).
root@default-ubuntu-1604:/etc/init.d# echo $?
0
```